### PR TITLE
Enable support for running on detached MR pipelines

### DIFF
--- a/gitlab-runner/src/client.rs
+++ b/gitlab-runner/src/client.rs
@@ -21,8 +21,19 @@ where
 const GITLAB_TRACE_UPDATE_INTERVAL: &str = "X-GitLab-Trace-Update-Interval";
 
 #[derive(Debug, Clone, Serialize)]
+struct FeaturesInfo {
+    refspecs: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct VersionInfo {
+    features: FeaturesInfo,
+}
+
+#[derive(Debug, Clone, Serialize)]
 struct JobRequest<'a> {
     token: &'a str,
+    info: VersionInfo,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -206,7 +217,13 @@ impl Client {
     }
 
     pub async fn request_job(&self) -> Result<Option<JobResponse>, Error> {
-        let request = JobRequest { token: &self.token };
+        let request = JobRequest {
+            token: &self.token,
+            info: VersionInfo {
+                // Setting `refspecs` is required to run detached MR pipelines.
+                features: FeaturesInfo { refspecs: true },
+            },
+        };
 
         let mut url = self.url.clone();
         url.path_segments_mut()


### PR DESCRIPTION
Detached MR pipelines require the runner to support the `refspecs`
feature:

https://gitlab.com/gitlab-org/gitlab/-/commit/bf639fd504c84929ff8542eef81578a6745bf428#c01214b277b69971fe5cc7555b37b2e8fe167585_30_30
https://about.gitlab.com/blog/2019/04/16/upgrade-runners-for-mr-pipelines/

Otherwise, any builds will fail with "Your runner is outdated, please
upgrade your runner". Since this crate actually checkout the Git repo
contents, we can just report the feature has supported, without needing
any drastic code changes.

Signed-off-by: Ryan Gonzalez <ryan.gonzalez@collabora.com>