### PR TITLE
mock: Make MockJobArtifactWhen public

### DIFF
--- a/gitlab-runner-mock/src/lib.rs
+++ b/gitlab-runner-mock/src/lib.rs
@@ -8,7 +8,9 @@ use wiremock::matchers::{body_json_schema, method, path, path_regex};
 use wiremock::{Mock, MockServer};
 
 mod job;
-pub use job::{MockJob, MockJobBuilder, MockJobState, MockJobStepName, MockJobStepWhen};
+pub use job::{
+    MockJob, MockJobArtifactWhen, MockJobBuilder, MockJobState, MockJobStepName, MockJobStepWhen,
+};
 
 mod api;
 use api::JobArtifactsDownloader;


### PR DESCRIPTION
This is already used in the public API, except the users could not
actually set it.

Signed-off-by: Ryan Gonzalez <ryan.gonzalez@collabora.com>