### PR TITLE
Avoid panics when failing to parse zip files

### DIFF
--- a/gitlab-runner/src/client.rs
+++ b/gitlab-runner/src/client.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 use thiserror::Error;
 use tokio::io::{AsyncWrite, AsyncWriteExt};
 use url::Url;
+use zip::result::ZipError;
 
 fn deserialize_null_default<'de, D, T>(deserializer: D) -> Result<T, D::Error>
 where
@@ -196,6 +197,8 @@ pub enum Error {
     Request(#[from] reqwest::Error),
     #[error("Failed to write to destination {0}")]
     WriteFailure(#[source] futures::io::Error),
+    #[error("Failed to parse zip file: {0}")]
+    ZipFile(#[from] ZipError),
     #[error("Empty trace")]
     EmptyTrace,
 }


### PR DESCRIPTION
This does require the removal of the From implementation; it couldn't be
converted to TryFrom due to lack of generic specialization
(https://github.com/rust-lang/rust/issues/50133).

Signed-off-by: Ryan Gonzalez <ryan.gonzalez@collabora.com>