### PR TITLE
Store the intermediate artifacts zip in a tempfile instead of memory

### DIFF
--- a/gitlab-runner/Cargo.toml
+++ b/gitlab-runner/Cargo.toml
@@ -12,7 +12,7 @@ readme = "../README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-reqwest = { version = "0.11.3", features = [ "json", "multipart" ] }
+reqwest = { version = "0.11.3", features = [ "json", "multipart", "stream" ] }
 tokio = { version = "1.12.0", features = [ "full" ] }
 url = "2.2.1"
 serde = { version = "1.0.125", features = [ "derive" ] }
@@ -28,6 +28,7 @@ parking_lot = "0.12.0"
 tracing-subscriber = "0.3.8"
 tracing = "0.1.30"
 doc-comment = "0.3.3"
+tokio-util = { version = "0.7", features = [ "io" ] }
 
 [dev-dependencies]
 tokio = { version = "1.5.0", features = [ "full", "test-util" ] }

--- a/gitlab-runner/src/run.rs
+++ b/gitlab-runner/src/run.rs
@@ -48,12 +48,16 @@ where
     });
 
     let r = if upload {
-        let mut uploader = Uploader::new(client, response);
-        let r = handler.upload_artifacts(&mut uploader).await;
-        if r.is_ok() {
-            uploader.upload().await.and(script_result)
+        if let Ok(mut uploader) = Uploader::new(client, &build_dir, response) {
+            let r = handler.upload_artifacts(&mut uploader).await;
+            if r.is_ok() {
+                uploader.upload().await.and(script_result)
+            } else {
+                r
+            }
         } else {
-            r
+            warn!("Failed to create uploader");
+            Err(())
         }
     } else {
         script_result


### PR DESCRIPTION
Otherwise, on very large uploads, we risk exhausting the available
memory.

Signed-off-by: Ryan Gonzalez <ryan.gonzalez@collabora.com>