### PR TITLE
Handle artifact resources missing the 'untracked' field

### DIFF
--- a/gitlab-runner-mock/src/api/request.rs
+++ b/gitlab-runner-mock/src/api/request.rs
@@ -86,15 +86,25 @@ impl Respond for JobRequestResponder {
                 .artifacts()
                 .iter()
                 .map(|a| {
-                    json!({
+                    let mut value = json!({
                         "name": a.name,
-                        "untracked": a.untracked,
                         "paths": a.paths,
                         "when": a.when,
                         "exprire_in": a.expire_in,
                         "artifact_type": a.artifact_type,
                         "artifact_format": a.artifact_format,
-                    })
+                    });
+
+                    // Missing values for 'untracked' should be treated as
+                    // false, so we "test" that out here.
+                    if a.untracked {
+                        value
+                            .as_object_mut()
+                            .unwrap()
+                            .insert("untracked".to_owned(), json!(a.untracked));
+                    }
+
+                    value
                 })
                 .collect();
             ResponseTemplate::new(201).set_body_json(json!({

--- a/gitlab-runner/src/client.rs
+++ b/gitlab-runner/src/client.rs
@@ -142,7 +142,7 @@ impl Default for ArtifactFormat {
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 pub(crate) struct JobArtifact {
     pub name: Option<String>,
-    #[serde(deserialize_with = "deserialize_null_default")]
+    #[serde(default, deserialize_with = "deserialize_null_default")]
     pub untracked: bool,
     pub paths: Vec<String>,
     #[serde(deserialize_with = "deserialize_null_default")]


### PR DESCRIPTION
A recent GitLab release doesn't always set this, so default it to false,
just like Go's deserialization (and thus the official runner) does.

Signed-off-by: Ryan Gonzalez <ryan.gonzalez@collabora.com>