### PR TITLE
Upload completed jobs and minor cleanup

### DIFF
--- a/gitlab-runner-mock/src/api/artifacts.rs
+++ b/gitlab-runner-mock/src/api/artifacts.rs
@@ -35,7 +35,7 @@ impl Respond for JobArtifactsUploader {
             return ResponseTemplate::new(403);
         };
 
-        if let Some(job) = self.mock.find_job(id) {
+        if let Some(job) = self.mock.get_job(id) {
             if token != job.token() {
                 ResponseTemplate::new(403)
             } else {
@@ -100,7 +100,7 @@ impl Respond for JobArtifactsDownloader {
             return ResponseTemplate::new(StatusCode::Forbidden);
         };
 
-        if let Some(job) = self.mock.find_job(id) {
+        if let Some(job) = self.mock.get_job(id) {
             if token != job.token() {
                 ResponseTemplate::new(StatusCode::Forbidden)
             } else {

--- a/gitlab-runner-mock/src/api/trace.rs
+++ b/gitlab-runner-mock/src/api/trace.rs
@@ -40,7 +40,7 @@ impl Respond for JobTraceResponder {
             return ResponseTemplate::new(400);
         };
 
-        if let Some(job) = self.mock.find_job(id) {
+        if let Some(job) = self.mock.get_job(id) {
             if token != job.token() {
                 ResponseTemplate::new(403)
             } else {

--- a/gitlab-runner-mock/src/api/update.rs
+++ b/gitlab-runner-mock/src/api/update.rs
@@ -33,7 +33,7 @@ impl Respond for JobUpdateResponder {
             .parse()
             .unwrap();
 
-        if let Some(job) = self.mock.find_job(id) {
+        if let Some(job) = self.mock.get_job(id) {
             if r.token != job.token() {
                 ResponseTemplate::new(403)
             } else {

--- a/gitlab-runner-mock/src/job.rs
+++ b/gitlab-runner-mock/src/job.rs
@@ -116,6 +116,25 @@ impl MockJob {
         builder.build()
     }
 
+    pub(crate) fn new_completed(name: String, id: u64, artifact: Vec<u8>) -> Self {
+        Self {
+            name,
+            id,
+            token: format!("job-token-{}", id),
+            variables: Vec::new(),
+            steps: Vec::new(),
+            dependencies: Vec::new(),
+            artifacts: Vec::new(),
+            inner: Arc::new(Mutex::new(MockJobInner {
+                state: MockJobState::Success,
+                state_updates: 2,
+                artifact: Arc::new(artifact),
+                log: Vec::new(),
+                log_patches: 0,
+            })),
+        }
+    }
+
     pub fn name(&self) -> &str {
         &self.name
     }

--- a/gitlab-runner-mock/src/lib.rs
+++ b/gitlab-runner-mock/src/lib.rs
@@ -107,6 +107,17 @@ impl GitlabRunnerMock {
         job
     }
 
+    pub fn add_completed_job(&self, name: String, artifact: Vec<u8>) -> MockJob {
+        let mut jobs = self.inner.jobs.lock().unwrap();
+        jobs.last_id += 1;
+
+        let job = MockJob::new_completed(name, jobs.last_id, artifact);
+
+        jobs.jobs.push(job.clone());
+
+        job
+    }
+
     pub fn job_builder(&self, name: String) -> MockJobBuilder {
         let mut jobs = self.inner.jobs.lock().unwrap();
         jobs.last_id += 1;

--- a/gitlab-runner-mock/src/lib.rs
+++ b/gitlab-runner-mock/src/lib.rs
@@ -135,7 +135,7 @@ impl GitlabRunnerMock {
         None
     }
 
-    fn find_job(&self, id: u64) -> Option<MockJob> {
+    pub fn get_job(&self, id: u64) -> Option<MockJob> {
         let jobs = self.inner.jobs.lock().unwrap();
         for job in jobs.jobs.iter() {
             if job.id() == id {

--- a/gitlab-runner/src/job.rs
+++ b/gitlab-runner/src/job.rs
@@ -218,11 +218,11 @@ impl ArtifactCache {
 }
 
 #[derive(Clone, Debug)]
-pub(crate) struct JobData {
+pub(crate) struct JobLog {
     trace: Arc<Mutex<BytesMut>>,
 }
 
-impl JobData {
+impl JobLog {
     pub(crate) fn new() -> Self {
         let trace = Arc::new(Mutex::new(BytesMut::new()));
         Self { trace }
@@ -248,7 +248,7 @@ impl JobData {
 pub struct Job {
     response: Arc<JobResponse>,
     client: Client,
-    data: JobData,
+    log: JobLog,
     build_dir: PathBuf,
     artifacts: ArtifactCache,
 }
@@ -258,12 +258,12 @@ impl Job {
         client: Client,
         response: Arc<JobResponse>,
         build_dir: PathBuf,
-        data: JobData,
+        log: JobLog,
     ) -> Self {
         Self {
             client,
             response,
-            data,
+            log,
             build_dir,
             artifacts: ArtifactCache::new(),
         }
@@ -279,7 +279,7 @@ impl Job {
     /// Normally [`outputln!`] should be used. This function directly puts data in the queue for
     /// the gitlab log and side-steps the tracing infrastructure
     pub fn trace<D: AsRef<[u8]>>(&self, data: D) {
-        self.data.trace(data.as_ref());
+        self.log.trace(data.as_ref());
     }
 
     /// Get the variable matching the given key

--- a/gitlab-runner/src/lib.rs
+++ b/gitlab-runner/src/lib.rs
@@ -71,7 +71,7 @@ use crate::client::Client;
 mod run;
 use crate::run::Run;
 pub mod job;
-use job::{Job, JobData};
+use job::{Job, JobLog};
 pub mod uploader;
 pub use logging::GitlabLayer;
 use tracing::instrument::WithSubscriber;
@@ -140,7 +140,7 @@ pub trait JobHandler: Send {
 pub struct Runner {
     client: Client,
     build_dir: PathBuf,
-    run_list: RunList<u64, JobData>,
+    run_list: RunList<u64, JobLog>,
 }
 
 impl Runner {

--- a/gitlab-runner/src/runlist.rs
+++ b/gitlab-runner/src/runlist.rs
@@ -8,7 +8,7 @@ pub(crate) struct RunListEntry<K, V>
 where
     K: Eq + std::hash::Hash,
 {
-    inner: Arc<Inner<K, V>>,
+    owner: Arc<Inner<K, V>>,
     key: K,
     value: V,
 }
@@ -29,7 +29,7 @@ where
     K: Eq + std::hash::Hash,
 {
     fn drop(&mut self) {
-        self.inner.remove(&self.key);
+        self.owner.remove(&self.key);
     }
 }
 
@@ -91,7 +91,7 @@ where
         r.insert(id.clone(), data.clone());
         self.inner.changed.send_replace(r.len());
         RunListEntry {
-            inner: self.inner.clone(),
+            owner: self.inner.clone(),
             key: id,
             value: data,
         }


### PR DESCRIPTION
These changes emerge from testing the lava-gitlab-runner against the gitlab-runner-mock. There are some minor renames for clarity, since some of the existing naming was quite confusing. The main addition is a simple API to upload a job that has already completed to the mock. In the case of the lava-gitlab-runner, it sources its LAVA test files from the artifacts of a prior job, so it's important to be able to upload such jobs.