### PR TITLE
Add support for cancellation

### DIFF
--- a/gitlab-runner/examples/demo-runner.rs
+++ b/gitlab-runner/examples/demo-runner.rs
@@ -3,7 +3,7 @@ use std::io::Read;
 use futures::AsyncWriteExt;
 use gitlab_runner::job::Job;
 use gitlab_runner::uploader::Uploader;
-use gitlab_runner::{outputln, JobHandler, JobResult, Phase, Runner};
+use gitlab_runner::{outputln, CancelClient, JobHandler, JobResult, Phase, Runner};
 use serde::Deserialize;
 use structopt::StructOpt;
 use tokio::signal::unix::{signal, SignalKind};
@@ -133,7 +133,7 @@ impl Run {
 
 #[async_trait::async_trait]
 impl JobHandler for Run {
-    async fn step(&mut self, script: &[String], _phase: Phase) -> JobResult {
+    async fn step(&mut self, script: &[String], _phase: Phase, _cancel: CancelClient) -> JobResult {
         for command in script {
             self.command(command).await?;
         }

--- a/gitlab-runner/src/lib.rs
+++ b/gitlab-runner/src/lib.rs
@@ -12,7 +12,7 @@
 //! runner can be implement as such:
 //!
 //! ```rust,no_run
-//! use gitlab_runner::{outputln, Runner, JobHandler, JobResult, Phase};
+//! use gitlab_runner::{outputln, CancelClient, Runner, JobHandler, JobResult, Phase};
 //! use std::path::PathBuf;
 //!
 //! #[derive(Debug)]
@@ -20,7 +20,7 @@
 //!
 //! #[async_trait::async_trait]
 //! impl JobHandler for Run {
-//!       async fn step(&mut self, script: &[String], phase: Phase) -> JobResult {
+//!       async fn step(&mut self, script: &[String], phase: Phase, _cancel: CancelClient) -> JobResult {
 //!           outputln!("Running script for phase {:?}", phase);
 //!           for s in script {
 //!             outputln!("Step: {}", s);
@@ -103,7 +103,7 @@ macro_rules! outputln {
 
 /// Result type for various stagings of a jobs
 pub type JobResult = Result<(), ()>;
-pub use client::Phase;
+pub use client::{CancelClient, Phase};
 
 /// Async trait for handling a single Job
 ///
@@ -118,7 +118,7 @@ pub trait JobHandler: Send {
     ///
     /// Note that gitlab concatinates the `before_script` and `script` arrays into a single
     /// [Phase::Script] step
-    async fn step(&mut self, script: &[String], phase: Phase) -> JobResult;
+    async fn step(&mut self, script: &[String], phase: Phase, cancel: CancelClient) -> JobResult;
     /// Upload artifacts to gitlab
     ///
     /// This gets called depending on whether the job definition calls for artifacts to be uploaded

--- a/gitlab-runner/tests/artifacts.rs
+++ b/gitlab-runner/tests/artifacts.rs
@@ -3,14 +3,19 @@ use std::io::Read;
 use futures::AsyncWriteExt;
 use gitlab_runner::job::Job;
 use gitlab_runner::uploader::Uploader;
-use gitlab_runner::{JobHandler, JobResult, Phase, Runner};
+use gitlab_runner::{CancelClient, JobHandler, JobResult, Phase, Runner};
 use gitlab_runner_mock::{GitlabRunnerMock, MockJobState, MockJobStepName, MockJobStepWhen};
 
 struct Upload();
 
 #[async_trait::async_trait]
 impl JobHandler for Upload {
-    async fn step(&mut self, _script: &[String], _phase: Phase) -> JobResult {
+    async fn step(
+        &mut self,
+        _script: &[String],
+        _phase: Phase,
+        _cancel: CancelClient,
+    ) -> JobResult {
         Ok(())
     }
 
@@ -71,7 +76,12 @@ impl Download {
 
 #[async_trait::async_trait]
 impl JobHandler for Download {
-    async fn step(&mut self, _script: &[String], _phase: Phase) -> JobResult {
+    async fn step(
+        &mut self,
+        _script: &[String],
+        _phase: Phase,
+        _cancel: CancelClient,
+    ) -> JobResult {
         Ok(())
     }
 }

--- a/gitlab-runner/tests/runhandler.rs
+++ b/gitlab-runner/tests/runhandler.rs
@@ -3,7 +3,7 @@ use std::pin::Pin;
 // Test the interaction intervals with the backend as driver by the runhandler
 //
 use gitlab_runner::job::Job;
-use gitlab_runner::{JobHandler, JobResult, Phase, Runner};
+use gitlab_runner::{CancelClient, JobHandler, JobResult, Phase, Runner};
 use gitlab_runner_mock::{GitlabRunnerMock, MockJob, MockJobState};
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
@@ -80,7 +80,12 @@ impl Logger {
 
 #[async_trait::async_trait]
 impl JobHandler for Logger {
-    async fn step(&mut self, _script: &[String], _phase: Phase) -> JobResult {
+    async fn step(
+        &mut self,
+        _script: &[String],
+        _phase: Phase,
+        _cancel: CancelClient,
+    ) -> JobResult {
         while let Some(command) = self.rx.recv().await {
             match command {
                 Control::Log(s, tx) => {


### PR DESCRIPTION
This adds a new parameter to JobHandler::step which can be queried to determine whether the Gitlab job has been cancelled. It is then the responsibility of the impl of JobHandler to determine how to respond. Note that no further updates can be made to a Gitlab job once it has been cancelled.

Behind the scenes, a monitor is spawned for each Gitlab job to query whether the job has been cancelled. Communication is via a simple flag: we call `make_canceler` which returns a pair `Canceler` and `CancelClient`. The `Canceler` can be used by the monitor process to signal that cancellation has occured; the `CancelClient` is handed to the `JobHandler` impls so that they can check.