### PR TITLE
Support for  `upload_multiple_artifacts`

### DIFF
--- a/gitlab-runner-mock/src/api/request.rs
+++ b/gitlab-runner-mock/src/api/request.rs
@@ -65,15 +65,16 @@ impl Respond for JobRequestResponder {
                 .dependencies()
                 .iter()
                 .map(|j| {
-                    let artifact = j.artifact();
-                    let artifact_file = if !artifact.is_empty() {
-                        Some(json!({
-                            "filename": "artifacts.zip",
-                            "size": artifact.len(),
-                        }))
-                    } else {
-                        None
-                    };
+                    let artifact_file = j
+                        .uploaded_artifacts()
+                        .find(|a| a.artifact_type.as_deref() == Some("archive"))
+                        .map(|artifact| {
+                            Some(json!({
+                                "filename": artifact.filename,
+                                "size": artifact.data.len(),
+                            }))
+                        });
+
                     json!({
                         "id": j.id() ,
                         "name": j.name() ,

--- a/gitlab-runner/Cargo.toml
+++ b/gitlab-runner/Cargo.toml
@@ -12,6 +12,7 @@ readme = "../README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+flate2 = "1"
 glob = "0.3"
 reqwest = { version = "0.11.3", features = [ "json", "multipart", "stream" ] }
 tokio = { version = "1.12.0", features = [ "full" ] }

--- a/gitlab-runner/Cargo.toml
+++ b/gitlab-runner/Cargo.toml
@@ -12,6 +12,7 @@ readme = "../README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+glob = "0.3"
 reqwest = { version = "0.11.3", features = [ "json", "multipart", "stream" ] }
 tokio = { version = "1.12.0", features = [ "full" ] }
 url = "2.2.1"

--- a/gitlab-runner/src/client.rs
+++ b/gitlab-runner/src/client.rs
@@ -4,6 +4,7 @@ use serde::de::Deserializer;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use std::collections::HashMap;
+use std::ops::Not;
 use std::time::Duration;
 use thiserror::Error;
 use tokio::io::{AsyncWrite, AsyncWriteExt};
@@ -22,9 +23,54 @@ where
 const GITLAB_TRACE_UPDATE_INTERVAL: &str = "X-GitLab-Trace-Update-Interval";
 const JOB_STATUS: &str = "Job-Status";
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Default, Clone, Serialize)]
 struct FeaturesInfo {
+    #[serde(skip_serializing_if = "Not::not")]
+    variables: bool,
+    #[serde(skip_serializing_if = "Not::not")]
+    image: bool,
+    #[serde(skip_serializing_if = "Not::not")]
+    services: bool,
+    #[serde(skip_serializing_if = "Not::not")]
+    artifacts: bool,
+    #[serde(skip_serializing_if = "Not::not")]
+    cache: bool,
+    #[serde(skip_serializing_if = "Not::not")]
+    shared: bool,
+    #[serde(skip_serializing_if = "Not::not")]
+    upload_multiple_artifacts: bool,
+    #[serde(skip_serializing_if = "Not::not")]
+    upload_raw_artifacts: bool,
+    #[serde(skip_serializing_if = "Not::not")]
+    session: bool,
+    #[serde(skip_serializing_if = "Not::not")]
+    terminal: bool,
+    #[serde(skip_serializing_if = "Not::not")]
     refspecs: bool,
+    #[serde(skip_serializing_if = "Not::not")]
+    masking: bool,
+    #[serde(skip_serializing_if = "Not::not")]
+    proxy: bool,
+    #[serde(skip_serializing_if = "Not::not")]
+    raw_variables: bool,
+    #[serde(skip_serializing_if = "Not::not")]
+    artifacts_exclude: bool,
+    #[serde(skip_serializing_if = "Not::not")]
+    multi_build_steps: bool,
+    #[serde(skip_serializing_if = "Not::not")]
+    trace_reset: bool,
+    #[serde(skip_serializing_if = "Not::not")]
+    trace_checksum: bool,
+    #[serde(skip_serializing_if = "Not::not")]
+    trace_size: bool,
+    #[serde(skip_serializing_if = "Not::not")]
+    vault_secrets: bool,
+    #[serde(skip_serializing_if = "Not::not")]
+    cancelable: bool,
+    #[serde(skip_serializing_if = "Not::not")]
+    return_exit_code: bool,
+    #[serde(skip_serializing_if = "Not::not")]
+    service_variables: bool,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -227,7 +273,10 @@ impl Client {
             token: &self.token,
             info: VersionInfo {
                 // Setting `refspecs` is required to run detached MR pipelines.
-                features: FeaturesInfo { refspecs: true },
+                features: FeaturesInfo {
+                    refspecs: true,
+                    ..Default::default()
+                },
             },
         };
 

--- a/gitlab-runner/src/run.rs
+++ b/gitlab-runner/src/run.rs
@@ -58,7 +58,7 @@ where
     let mut overall_result = script_result;
 
     if !cancel_token.is_cancelled() {
-        for artifact in response.artifacts.iter().take(1) {
+        for artifact in response.artifacts.iter() {
             if process_artifact(
                 artifact,
                 script_result,

--- a/gitlab-runner/src/run.rs
+++ b/gitlab-runner/src/run.rs
@@ -107,7 +107,13 @@ where
         return Ok(());
     }
 
-    let mut uploader = match Uploader::new(client, build_dir, response.clone()) {
+    let mut uploader = match Uploader::new(
+        client,
+        build_dir,
+        response.id,
+        response.token.clone(),
+        artifact,
+    ) {
         Ok(uploader) => uploader,
         Err(_) => {
             warn!("Failed to create uploader");


### PR DESCRIPTION
This provides support for the gitlab runner feature tag `upload_multiple_artifacts`, and more generally brings artifact handling into closer alignment with the Gitlab runner. There are several parts to this:

- Client crates specify the files they can provide, rather than taking responsibility for constructing an output zip.
- Gzip format as well as ZIP format artifacts are supported.
- User selection of desired artifacts is supported, including some limited support for globbing via the `glob` crate.

A major driver here is that if a client crate is able to provide junit test results, supporting this feature tag and exposing that file now provides integration with the gitlab pipelines test tab feature, and without the client crate having to be aware of this in any deep way.