### PR TITLE
dependabot: Ignore tokio minor versions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -19,6 +19,8 @@ updates:
     # Not yet supported. See <https://github.com/dependabot/dependabot-core/issues/4009>.
     # versioning-strategy: "increase-if-necessary"
     ignore:
+      - dependency-name: "tokio"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
       - dependency-name: "serde"
         update-types: ["version-update:semver-minor", "version-update:semver-patch"]
       - dependency-name: "*"


### PR DESCRIPTION
Updated to match the configs of obs-gitlab-runner and lava-gitlab-runner