### PR TITLE
Retry failed artifact downloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -624,6 +624,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tokio-retry2",
  "tokio-util",
  "tracing",
  "tracing-subscriber",
@@ -1959,6 +1960,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-retry2"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1264d076dd34560544a2799e40e457bd07c43d30f4a845686b031bcd8455c84f"
+dependencies = [
+ "pin-project",
+ "rand",
  "tokio",
 ]
 

--- a/gitlab-runner-mock/src/lib.rs
+++ b/gitlab-runner-mock/src/lib.rs
@@ -34,12 +34,19 @@ struct ExpectedMetadata {
     architecture: Option<String>,
 }
 
+#[derive(Default, Clone)]
+struct ArtifactDownloadsCounter {
+    count: u32,
+    failure_count: u32,
+}
+
 struct Inner {
     server: MockServer,
     runner_token: String,
     jobs: Mutex<JobData>,
     update_interval: Mutex<u32>,
     expected_metadata: Mutex<ExpectedMetadata>,
+    artifact_downloads_counter: Mutex<ArtifactDownloadsCounter>,
 }
 
 #[derive(Clone)]
@@ -60,6 +67,7 @@ impl GitlabRunnerMock {
             jobs: Mutex::new(jobs),
             update_interval: Mutex::new(3),
             expected_metadata: Mutex::new(ExpectedMetadata::default()),
+            artifact_downloads_counter: Mutex::new(ArtifactDownloadsCounter::default()),
         };
         let server = Self {
             inner: Arc::new(inner),
@@ -200,5 +208,13 @@ impl GitlabRunnerMock {
 
     pub fn set_expected_metadata_architecture<S: Into<String>>(&self, architecture: S) {
         self.inner.expected_metadata.lock().unwrap().architecture = Some(architecture.into());
+    }
+
+    pub fn set_inject_artifact_download_failures(&self, failure_count: u32) {
+        self.inner
+            .artifact_downloads_counter
+            .lock()
+            .unwrap()
+            .failure_count = failure_count;
     }
 }

--- a/gitlab-runner/Cargo.toml
+++ b/gitlab-runner/Cargo.toml
@@ -22,7 +22,7 @@ serde_json = "1.0.64"
 thiserror = "2.0.11"
 bytes = "1.9.0"
 zip = "4.1.0"
-pin-project = "1.0.7"
+pin-project = "1.1.10"
 futures = "0.3.15"
 async-trait = "0.1.86"
 tempfile = "3.15.0"
@@ -34,6 +34,7 @@ sha2 = "0.10.8"
 hmac = "0.12.1"
 rand = "0.9.0"
 tokio-util = { version = "0.7.10", features = [ "io" ] }
+tokio-retry2 = { version = "0.5.7", features = ["jitter"] }
 
 [dev-dependencies]
 tokio = { version = "1.44.2", features = [ "full", "test-util" ] }

--- a/gitlab-runner/tests/artifacts.rs
+++ b/gitlab-runner/tests/artifacts.rs
@@ -103,6 +103,8 @@ impl JobHandler for Download {
 #[tokio::test]
 async fn upload_download() {
     let mock = GitlabRunnerMock::start().await;
+    mock.set_inject_artifact_download_failures(2);
+
     let mut upload = mock.job_builder("upload artifact".to_string());
     upload.add_step(
         MockJobStepName::Script,


### PR DESCRIPTION
Right now, if downloading an artifact fails due to, say, network or server errors, the runner crate simply returns an error. This isn't ideal, since *some* errors will inevitably occur; even the official runner implementation has retries for artifact downloads.

This adds a simple retry system on top of downloads: if a "retriable" error occurs (namely, reqwest-level error or a 5xx status code), then the download will be repeatedly retried up to 10 times.

In order to be able to test the change, this adds a new method to the mock API, `set_inject_artifact_download_failures`, which will cause N artifact downloads to fail before one can succeed.

Fixes: collabora/lava-gitlab-runner#102