### PR TITLE
Drop Eq requirement on UploadableFile

### DIFF
--- a/gitlab-runner/Cargo.toml
+++ b/gitlab-runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gitlab-runner"
-version = "0.2.0"
+version = "0.3.0-rc1"
 authors = ["Sjoerd Simons <sjoerd@collabora.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/gitlab-runner/examples/demo-runner.rs
+++ b/gitlab-runner/examples/demo-runner.rs
@@ -135,7 +135,6 @@ impl Run {
     }
 }
 
-#[derive(PartialEq, Eq)]
 enum DemoFile {
     ReadMe,
     Fact { index: usize, value: String },

--- a/gitlab-runner/src/lib.rs
+++ b/gitlab-runner/src/lib.rs
@@ -60,7 +60,7 @@ pub use client::Phase;
 /// `get_path` method is required so that the globbing Gitlab expects
 /// can be performed without the handler needing to be involved.
 #[async_trait::async_trait]
-pub trait UploadableFile: Eq {
+pub trait UploadableFile {
     /// The type of the data stream returned by
     /// [`get_data`](Self::get_data)
     type Data<'a>: AsyncRead + Send + Unpin


### PR DESCRIPTION
This isn't actually used anywhere in the runner code, and it can be rather annoying to comply with if you need to manually implement it due to holding non-Eq fields (e.g. storing a `File` inline on the struct).