### PR TITLE
actions: Switch clippy to a dedicated action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,10 @@ jobs:
         with:
             toolchain: "1.85"
             components: clippy
-      - run: cargo clippy --all-targets --all-features -- -D warnings
+      - uses: clechasseur/rs-clippy-check@v4.0.5
+        with:
+          args: --all-targets --all-features -- -D warnings
+
 
   clippy-latest:
     name: cargo clippy latest
@@ -63,7 +66,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      - run: cargo clippy --all-targets --all-features -- -D warnings
+      - uses: clechasseur/rs-clippy-check@v4.0.5
+        with:
+          args: --all-targets --all-features
 
   minimal-dependencies:
     name: minimal direct dependencies


### PR DESCRIPTION
Currently the "clippy latest" action starts failing whenever there are new lints in the latest clippy giving warnings.  The main reason for the latest lint is really to provide early warnings, rather then to act as a pass/fail.

Switch to the rs-clippy-check action which wraps clippy and creates annotations on issues, such that they're visibile in the review. For clippy latest remove `-D warnings` which avoids the lint failing on warnings. For the clippy stable check, warnings stay denied as that's meant to provide a pass/fail result