### PR TITLE
Send a non-empty content-type for job trace updates

### DIFF
--- a/gitlab-runner-mock/src/api/trace.rs
+++ b/gitlab-runner-mock/src/api/trace.rs
@@ -32,6 +32,14 @@ impl Respond for JobTraceResponder {
             return ResponseTemplate::new(StatusCode::FORBIDDEN);
         };
 
+        // Recent versions of GitLab expect an empty content-type to imply JSON:
+        // https://gitlab.com/gitlab-org/gitlab/-/commit/c9b271bfba59e0464d7e7eed7344aab14b825aa3
+        // so hard-require it.
+        request
+            .headers
+            .get(&http::header::CONTENT_TYPE)
+            .expect("Missing content type");
+
         let (start, end) = if let Some(range) = request.headers.get("Content-Range") {
             let mut split = range
                 .to_str()

--- a/gitlab-runner/src/client.rs
+++ b/gitlab-runner/src/client.rs
@@ -401,6 +401,7 @@ impl Client {
             .patch(url)
             .header("JOB-TOKEN", token)
             .header(reqwest::header::CONTENT_RANGE, range)
+            .header(reqwest::header::CONTENT_TYPE, "text/plain")
             .body(body)
             .send()
             .await?;


### PR DESCRIPTION
Due to a recent security issue in GitLab, where it seems you could sneak in problematic JSON payloads with an empty content-type, all requests to API methods will treat an empty content-type as JSON:

https://gitlab.com/gitlab-org/gitlab/-/commit/c9b271bfba59e0464d7e7eed7344aab14b825aa3

However, this means that if you send a non-JSON payload to any API endpoint, it *must* now have a content-type set, otherwise the server will reject it with a 400 error.