### PR TITLE
Make artifact path matching match the official runner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -774,6 +774,7 @@ dependencies = [
  "gitlab-runner-mock",
  "glob",
  "hmac 0.13.0",
+ "normalize-path",
  "parking_lot",
  "pin-project",
  "rand 0.10.1",
@@ -1358,6 +1359,12 @@ dependencies = [
  "spin",
  "version_check",
 ]
+
+[[package]]
+name = "normalize-path"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5438dd2b2ff4c6df6e1ce22d825ed2fa93ee2922235cc45186991717f0a892d"
 
 [[package]]
 name = "nu-ansi-term"

--- a/gitlab-runner/Cargo.toml
+++ b/gitlab-runner/Cargo.toml
@@ -36,6 +36,7 @@ hmac = "0.13.0"
 rand = "0.10.1"
 tokio-util = { version = "0.7.18", features = [ "io" ] }
 tokio-retry2 = { version = "0.9.1", features = ["jitter"] }
+normalize-path = "0.2.1"
 
 [dev-dependencies]
 tokio = { version = "1.50.0", features = [ "full", "test-util" ] }

--- a/gitlab-runner/src/run.rs
+++ b/gitlab-runner/src/run.rs
@@ -1,4 +1,5 @@
 use bytes::Bytes;
+use normalize_path::NormalizePath;
 use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -85,6 +86,48 @@ where
     overall_result
 }
 
+fn artifact_path_matches<I: IntoIterator>(file_path: &Path, patterns: I) -> bool
+where
+    I::Item: AsRef<str>,
+{
+    patterns.into_iter().any(|test_path| {
+        let test_path = Path::new(test_path.as_ref());
+        let Some(test_path) = test_path.try_normalize() else {
+            return false;
+        };
+        match glob::Pattern::new(&test_path.to_string_lossy()) {
+            Ok(pattern) => file_path.ancestors().any(|p| {
+                pattern.matches_path_with(
+                    p,
+                    glob::MatchOptions {
+                        require_literal_separator: true,
+                        ..glob::MatchOptions::new()
+                    },
+                )
+            }),
+            Err(_) => file_path.ancestors().any(|p| p == test_path),
+        }
+    })
+}
+
+#[test]
+fn test_artifact_path_matches() {
+    assert!(artifact_path_matches(Path::new("abc"), &["abc"]));
+    assert!(artifact_path_matches(Path::new("abc"), &["a*c"]));
+    assert!(artifact_path_matches(Path::new("abc/d"), &["abc"]));
+    assert!(artifact_path_matches(Path::new("abc/d"), &["a*c"]));
+    assert!(!artifact_path_matches(Path::new("ab/c"), &["a*c"]));
+    assert!(artifact_path_matches(Path::new("abc"), &["."]));
+    assert!(artifact_path_matches(Path::new("abc"), &["./abc//"]));
+    assert!(artifact_path_matches(Path::new("a/b/c"), &["a/**/c"]));
+    assert!(artifact_path_matches(Path::new("a/b/d/e/f/c"), &["a/**/c"]));
+    assert!(artifact_path_matches(
+        Path::new("a/b/c.yaml"),
+        &["**/*.yaml"]
+    ));
+    assert!(artifact_path_matches(Path::new("["), &["["]));
+}
+
 async fn process_artifact<J, U>(
     artifact: &JobArtifact,
     script_result: JobResult,
@@ -124,16 +167,13 @@ where
     let mut uploaded = 0;
 
     for file in handler.get_uploadable_files().await? {
-        if artifact
-            .paths
-            .iter()
-            .any(|path| match glob::Pattern::new(path) {
-                Ok(pattern) => pattern.matches(&file.get_path()),
-                Err(_) => path == &file.get_path(),
-            })
-        {
-            let path = file.get_path();
-            match uploader.file(path.to_string()).await {
+        let file_path = Path::new(&file.get_path().as_ref()).normalize();
+
+        if artifact_path_matches(&file_path, &artifact.paths) {
+            match uploader
+                .file(file_path.to_string_lossy().into_owned())
+                .await
+            {
                 Ok(mut upload) => {
                     let mut data = file.get_data().await?;
                     match futures::io::copy(&mut data, &mut upload).await {

--- a/gitlab-runner/tests/artifacts.rs
+++ b/gitlab-runner/tests/artifacts.rs
@@ -17,6 +17,7 @@ use gitlab_runner_mock::{
 enum TestFile {
     Test,
     Test2,
+    TestDir,
 }
 
 #[async_trait::async_trait]
@@ -26,13 +27,15 @@ impl UploadableFile for TestFile {
     fn get_path(&self) -> Cow<'_, str> {
         match self {
             TestFile::Test => "test".into(),
-            TestFile::Test2 => "test2".into(),
+            TestFile::Test2 => "./test2".into(),
+            TestFile::TestDir => "dir/test".into(),
         }
     }
     async fn get_data(&self) -> Result<&'_ [u8], ()> {
         Ok(match self {
             TestFile::Test => b"testdata".as_slice(),
             TestFile::Test2 => b"testdata2".as_slice(),
+            TestFile::TestDir => b"testdata-dir".as_slice(),
         })
     }
 }
@@ -48,7 +51,9 @@ impl JobHandler<TestFile> for Upload {
     async fn get_uploadable_files(
         &mut self,
     ) -> Result<Box<dyn Iterator<Item = TestFile> + Send>, ()> {
-        Ok(Box::new([TestFile::Test, TestFile::Test2].into_iter()))
+        Ok(Box::new(
+            [TestFile::Test, TestFile::Test2, TestFile::TestDir].into_iter(),
+        ))
     }
 }
 
@@ -65,22 +70,20 @@ impl Download {
                 .expect("No artifacts to download");
             let mut names: Vec<_> = artifact.file_names().collect();
             names.sort_unstable();
-            assert_eq!(2, names.len());
-            assert_eq!(&["test", "test2"], names.as_slice());
+            assert_eq!(3, names.len());
+            assert_eq!(&["dir/test", "test", "test2"], names.as_slice());
 
-            let mut f = artifact.file("test").expect("Testfile not available");
-            assert_eq!(f.name(), "test");
-            let mut data = Vec::new();
-            f.read_to_end(&mut data).expect("Failed to read content");
-            assert_eq!("testdata".as_bytes(), &*data);
-            drop(f);
-
-            let mut f = artifact.file("test2").expect("Testfile not available");
-            assert_eq!(f.name(), "test2");
-            let mut data = Vec::new();
-            f.read_to_end(&mut data).expect("Failed to read content");
-            assert_eq!("testdata2".as_bytes(), &*data);
-            drop(f);
+            for (name, expected) in [
+                ("test", "testdata"),
+                ("test2", "testdata2"),
+                ("dir/test", "testdata-dir"),
+            ] {
+                let mut f = artifact.file(name).expect("Testfile not available");
+                assert_eq!(f.name(), name);
+                let mut data = Vec::new();
+                f.read_to_end(&mut data).expect("Failed to read content");
+                assert_eq!(expected.as_bytes(), &*data);
+            }
 
             /* Try reading first data file a second time */
             let mut f = artifact.file("test").expect("Testfile not available");
@@ -113,7 +116,11 @@ async fn upload_download() {
         MockJobStepWhen::OnSuccess,
         false,
     );
-    upload.add_artifact_paths(vec!["*".to_string()]);
+    upload.add_artifact_paths(vec![
+        "dir".to_string(),
+        "./*2".to_string(),
+        "test/".to_string(),
+    ]);
     let upload = upload.build();
     mock.enqueue_job(upload.clone());
 
@@ -236,7 +243,7 @@ async fn multiple_upload() {
                     let mut z = ZipArchive::new(std::io::Cursor::new(artifact.data.as_slice()))
                         .expect("failed to open zip archive");
                     saw_zip = true;
-                    assert_eq!(z.len(), 2);
+                    assert_eq!(z.len(), 3);
                     for ix in 0..z.len() {
                         let mut f = z.by_index(ix).expect("failed to get zip file");
                         match f.name() {
@@ -249,6 +256,11 @@ async fn multiple_upload() {
                                 let mut data = Vec::new();
                                 f.read_to_end(&mut data).expect("failed to read zip file");
                                 assert_eq!(b"testdata2", data.as_slice());
+                            }
+                            "dir/test" => {
+                                let mut data = Vec::new();
+                                f.read_to_end(&mut data).expect("failed to read zip file");
+                                assert_eq!(b"testdata-dir", data.as_slice());
                             }
                             _ => {
                                 unreachable!("unknown file in archive");


### PR DESCRIPTION
Older versions of gitlab-runner did not filter uploaded artifacts at all, regardless of the value of `artifacts` the user gave. In commit eccfdbc1a859f811a41d94b0acd0498f2a1eebb8, artifact filtering was added, by treating `artifacts` entries as glob patterns and matching them against the artifact paths the runner instances proposed. However, gitlab-runner itself instead uses doublestar to traverse the current tree for artifacts, which has a few notable implications:

- Paths are normalized first with filepath.Clean & filepath.ToSlash:

  https://github.com/bmatcuk/doublestar/blob/a9ad9e0ef4d6b7e4443090e9a7201d847a881711/utils.go#L74-L80

  So `file` and `./file//` are both the same pattern and will match `file`. (We don't care too much about ToSlash for now, since that should only have an effect for the Windows path separator).

- If a pattern matches a directory, the full subtree is added to the archive.

- Wildcards `*` and `?` retain the usual filesystem-level semantics of not crossing path components.

These behaviors do not line up with the current glob matches, which will only do an exact match on the full artifact path with the default glob options (`require_literal_separator: false`). The result is:

- All globs are effectively recursive globs, so `a/b/c` will be matched by any of `a/*`, `*b*`, `a?b?c`.
- You need to add an explicit trailing wildcard `/*` to directories, otherwise none of their contents get included.
  - e.g. `dir` or `dir/` will not match `dir/file`, as it will be looking for full paths named `dir` or `dir/` (including the trailing slash, due to the lack of normalization).

To fix this, both the declared artifact path and UploadableFile's path (for consistency) are normalized, and then the patterns are matched on successive ancestors of the current path, while telling `glob` that it needs to give the `/` special treatment.

Technically this leaves some other gitlab-runner behavior on the table, such as support for brace expansion, or the aforementioned Windows separator support, or handling absolute paths:

https://gitlab.com/gitlab-org/gitlab-runner/-/blob/fc6a8943d99928a9d293186be03674c333fd09fa/commands/helpers/file_archiver.go#L191

But that's all leaning more towards fringe functionality that we probably don't care about here (at least not for now).